### PR TITLE
Add async feature for webcam

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Clone the repository and install the dependencies below.
 
 Debian:
 ```sh
-sudo apt-get install ffmpeg v4l2loopback-dkms
+sudo apt-get install ffmpeg v4l2loopback-dkms inotify-tools
 ```
 
 Ensure that v4l2loopback-dkms is version 0.12.5-1 or later to ensure full functionality.
@@ -84,6 +84,14 @@ Then, run the video looper script to generate a lengthened video and stream it t
 ```sh
 weffe -v your_video.mp4
 weffe -sv dont_reverse_this_video.mp4
+```
+
+### Monitor Output
+
+This option, released in v1.1, checks if the virtual webcam is being fed into an application (e.g. video calling software) and runs the webcam on demand. This feature is good if there are a lot of effects on the webcam as it can save computer resources while video calling platforms are off. In the off time, it streams a blank color to the webcam. However, it is still being tested and does not work when applications regularly probe the webcam to check if it's streaming (e.g. Discord opens and closes the webcam approx. every 3 seconds). This option requires the optional `inotify-tools` dependency.
+
+```sh
+weffe -M
 ```
 
 ### Extra Options

--- a/help.md
+++ b/help.md
@@ -2,7 +2,7 @@ Webcam Video Effects
 
 Stream a video to a fake webcam or add effects to your current webcam video stream.
 
-./weffe [-a] [-r] [-s] [-h] [-p] [-S] [-i number] [-o number] [-v filename] [-w filename] [-t text] [-b text] [-f text] [-B pattern] [-z pattern]
+./weffe [-a] [-r] [-s] [-h] [-p] [-M] [-S] [-i number] [-o number] [-v filename] [-w filename] [-t text] [-b text] [-f text] [-B pattern] [-z pattern]
 
 -a
     activate the virtual webcam (requires sudo); use -o to choose a custom video stream
@@ -18,6 +18,9 @@ Stream a video to a fake webcam or add effects to your current webcam video stre
 
 -p
     print the generated webcam command before executing it (for debugging only)
+
+-M
+    monitor output streams and only stream the output when an application is trying to access it
 
 -S
     when blurring the background, use a strong blur

--- a/weffe
+++ b/weffe
@@ -21,8 +21,11 @@ strongblur=false
 rotatefactor="2*PI*t/6"
 activate=false
 rootdir="$(dirname "$0")"
+persistent=false
 
-while getopts ":hv:rsi:o:w:t:b:f:z:B:Spa" opt; do
+set -e
+
+while getopts ":hv:rsi:o:w:t:b:f:z:B:SpaP" opt; do
   case $opt in
   	a) activate=true
 	;;
@@ -57,6 +60,8 @@ while getopts ":hv:rsi:o:w:t:b:f:z:B:Spa" opt; do
 	;;
 	p) printffmpeg=true
 	;;
+	P) persistent=true
+	;;
     \?) echo "Invalid option -$OPTARG" >&2
 		exit 0
     ;;
@@ -71,6 +76,8 @@ then
 	exit 0
 fi
 
+firstinput=false
+
 if [[ $video != false ]]
 then # if streaming a video
 	if [[ $process = true ]]
@@ -82,8 +89,10 @@ then # if streaming a video
         \cp -r "$video" stream.mp4
     fi
     inputstr="-stream_loop -1 -re -i stream.mp4"
+    firstinput="stream.mp4"
 else # if streaming from a webcam
 	inputstr="-i /dev/video$input"
+	firstinput="/dev/video$input"
 fi
 
 # process blur background
@@ -184,9 +193,16 @@ fi
 # TODO: allow whitespaces in file names and filter text string
 # filterstr=$(echo "$filterstr" | sed -r 's/\s+//g')
 
+outputsize=$(ffprobe -v error -show_entries stream=width,height -of csv=p=0:s=x $firstinput)
+
 filterstr="[0]split=1[v];${filterstr}[v]format=yuv420p[v]"
-ffmpegstr="ffmpeg $inputstr \
+alt_filterstr="color=c=#543c00:s=$outputsize,format=yuv420p[v]"
+
+ffmpegstr="ffmpeg -hide_banner -loglevel warning $inputstr \
 	-filter_complex \"${filterstr}\" \
+	-map "[v]" -f v4l2 \"/dev/video$output\""
+alt_ffmpegstr="ffmpeg -hide_banner -loglevel warning \
+	-filter_complex \"${alt_filterstr}\" \
 	-map "[v]" -f v4l2 \"/dev/video$output\""
 
 # remove more whitespace
@@ -199,4 +215,25 @@ then
 	echo "$ffmpegstr"
 fi
 
-sh -c "$ffmpegstr"
+if [[ $persistent == false ]]
+then
+	while true
+	do
+		printf "Waiting for camera to be opened...\n"
+		sh -c "$alt_ffmpegstr" &
+		pid=$!
+		sleep 0.1 # wait for camera to stop thinking it's still open
+		inotifywait -qq -e open /dev/video$output
+		printf "Camera opened\n"
+		kill $pid
+		sh -c "$ffmpegstr" &
+		pid=$!
+		printf "Waiting for close\n"
+		inotifywait -qq -e close /dev/video$output
+		printf "Closed, revert to simple film\n"
+		kill $pid &
+		tail --pid=$! -f /dev/null
+	done
+else
+	sh -c "$ffmpegstr"
+fi

--- a/weffe
+++ b/weffe
@@ -72,7 +72,7 @@ if $activate
 then
 	echo "Initializing virtual camera at /dev/video${output}"
 	echo "This may require sudo access"
-	sudo modprobe v4l2loopback exclusive_caps=1 video_nr=$output card_label="Webcam Video Effects"
+	sudo modprobe v4l2loopback exclusive_caps=1 video_nr=$output card_label="Weffe"
 	exit 0
 fi
 
@@ -82,9 +82,11 @@ if [[ $video != false ]]
 then # if streaming a video
 	if [[ $process = true ]]
 	then # process the video input
-        ffmpeg -y -i "$video" -filter_complex "[0]split=2[fr][rv]; \
+		echo "Pre-processing $video"
+        ffmpeg -hide_banner -loglevel warning -y -i "$video" -filter_complex "[0]split=2[fr][rv]; \
             [rv]reverse[rv];[fr][rv]concat=n=2:v=1:a=0,format=yuv420p[v]" \
             -map "[v]" -g 30 stream.mp4
+        echo "Finished processing $video"
     else
         \cp -r "$video" stream.mp4
     fi
@@ -196,7 +198,7 @@ fi
 outputsize=$(ffprobe -v error -show_entries stream=width,height -of csv=p=0:s=x $firstinput)
 
 filterstr="[0]split=1[v];${filterstr}[v]format=yuv420p[v]"
-alt_filterstr="color=c=#543c00:s=$outputsize,format=yuv420p[v]"
+alt_filterstr="color=c=#543c00:s=$outputsize,realtime,format=yuv420p[v]"
 
 ffmpegstr="ffmpeg -hide_banner -loglevel warning $inputstr \
 	-filter_complex \"${filterstr}\" \
@@ -225,9 +227,11 @@ set +e
 state_machine='
 	BEGIN {
 		state = "START_IDLE"
+		count = 0
 		print "IDLE"
 	}
 	/OPEN/ {
+		count++
 		if (state == "START_IDLE") {
 			state = "IDLE"
 		} else if (state == "IDLE") {
@@ -240,22 +244,29 @@ state_machine='
 			print "STOP"
 		} else if (state == "STOP_STREAM") {
 			state = "RESTART_STREAM"
+		} else if (state == "STOP_IDLE" || state == "STREAM" || state == "RESTART_STREAM" ) {
+			# Waiting for previous instance to close to switch streams.
 		} else {
 			print "Unexpected OPEN event in state " state
 			next
 		}
 	}
 	/CLOSE/ {
+		count--
 		if (state == "IDLE") {
 			exit
 		} else if (state == "STOP_IDLE" || state == "RESTART_STREAM") {
 			state = "START_STREAM"
 			print "STREAM"
 		} else if (state == "START_STREAM") {
-			state = "ABORT_STREAM"
+			if (count == 0) {
+				state = "ABORT_STREAM"
+			}
 		} else if (state == "STREAM") {
-			state = "STOP_STREAM"
-			print "STOP"
+			if (count == 1) {
+				state = "STOP_STREAM"
+				print "STOP"
+			}
 		} else if (state == "STOP_STREAM") {
 			state = "START_IDLE"
 			print "IDLE"
@@ -265,7 +276,7 @@ state_machine='
 		}
 	}
 	{
-		print "<" state ">"
+		print "<" state " @ " count ">"
 	}'
 
 set -e

--- a/weffe
+++ b/weffe
@@ -215,25 +215,76 @@ then
 	echo "$ffmpegstr"
 fi
 
-if [[ $persistent == false ]]
+if [[ $persistent != false ]]
 then
-	while true
-	do
-		printf "Waiting for camera to be opened...\n"
-		sh -c "$alt_ffmpegstr" &
-		pid=$!
-		sleep 0.1 # wait for camera to stop thinking it's still open
-		inotifywait -qq -e open /dev/video$output
-		printf "Camera opened\n"
-		kill $pid
-		sh -c "$ffmpegstr" &
-		pid=$!
-		printf "Waiting for close\n"
-		inotifywait -qq -e close /dev/video$output
-		printf "Closed, revert to simple film\n"
-		kill $pid &
-		tail --pid=$! -f /dev/null
-	done
-else
 	sh -c "$ffmpegstr"
+	exit
 fi
+
+set +e
+state_machine='
+	BEGIN {
+		state = "START_IDLE"
+		print "IDLE"
+	}
+	/OPEN/ {
+		if (state == "START_IDLE") {
+			state = "IDLE"
+		} else if (state == "IDLE") {
+			state = "STOP_IDLE"
+			print "STOP"
+		} else if (state == "START_STREAM") {
+			state = "STREAM"
+		} else if (state == "ABORT_STREAM") {
+			state = "STOP_STREAM"
+			print "STOP"
+		} else if (state == "STOP_STREAM") {
+			state = "RESTART_STREAM"
+		} else {
+			print "Unexpected OPEN event in state " state
+			next
+		}
+	}
+	/CLOSE/ {
+		if (state == "IDLE") {
+			exit
+		} else if (state == "STOP_IDLE" || state == "RESTART_STREAM") {
+			state = "START_STREAM"
+			print "STREAM"
+		} else if (state == "START_STREAM") {
+			state = "ABORT_STREAM"
+		} else if (state == "STREAM") {
+			state = "STOP_STREAM"
+			print "STOP"
+		} else if (state == "STOP_STREAM") {
+			state = "START_IDLE"
+			print "IDLE"
+		} else {
+			print "Unexpected CLOSE event in state " state
+			next
+		}
+	}
+	{
+		print "<" state ">"
+	}'
+
+set -e
+
+inotifywait -q -me open,close /dev/video$output \
+	| stdbuf -oL awk "$state_machine" \
+	| while read -r action
+		do
+			echo "$action"
+			if [ "$action" = "IDLE" ]
+			then
+				sh -c "$alt_ffmpegstr" &
+				pid=$!
+			elif [ "$action" = "STREAM" ]
+			then
+				sh -c "$ffmpegstr" &
+				pid=$!
+			elif [ "$action" = "STOP" ]
+			then
+				kill $pid &
+			fi
+		done

--- a/weffe
+++ b/weffe
@@ -21,11 +21,11 @@ strongblur=false
 rotatefactor="2*PI*t/6"
 activate=false
 rootdir="$(dirname "$0")"
-persistent=false
+monitor=false
 
 set -e
 
-while getopts ":hv:rsi:o:w:t:b:f:z:B:SpaP" opt; do
+while getopts ":hv:rsi:o:w:t:b:f:z:B:SpaM" opt; do
   case $opt in
   	a) activate=true
 	;;
@@ -60,7 +60,7 @@ while getopts ":hv:rsi:o:w:t:b:f:z:B:SpaP" opt; do
 	;;
 	p) printffmpeg=true
 	;;
-	P) persistent=true
+	M) monitor=true
 	;;
     \?) echo "Invalid option -$OPTARG" >&2
 		exit 0
@@ -200,10 +200,11 @@ outputsize=$(ffprobe -v error -show_entries stream=width,height -of csv=p=0:s=x 
 filterstr="[0]split=1[v];${filterstr}[v]format=yuv420p[v]"
 alt_filterstr="color=c=#543c00:s=$outputsize,realtime,format=yuv420p[v]"
 
-ffmpegstr="ffmpeg -hide_banner -loglevel warning $inputstr \
+# potentially add -loglevel warning in a -q flag
+ffmpegstr="ffmpeg -hide_banner $inputstr \
 	-filter_complex \"${filterstr}\" \
 	-map "[v]" -f v4l2 \"/dev/video$output\""
-alt_ffmpegstr="ffmpeg -hide_banner -loglevel warning \
+alt_ffmpegstr="ffmpeg -hide_banner \
 	-filter_complex \"${alt_filterstr}\" \
 	-map "[v]" -f v4l2 \"/dev/video$output\""
 
@@ -217,7 +218,7 @@ then
 	echo "$ffmpegstr"
 fi
 
-if [[ $persistent != false ]]
+if [[ $monitor == false ]]
 then
 	sh -c "$ffmpegstr"
 	exit


### PR DESCRIPTION
Makes weffe only run all filters when a video camera is actually on. For weffe to always be on, use the `-P` (persistent) flag.